### PR TITLE
Adding @font-size to fix bugs with atom-ide-ui

### DIFF
--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -65,6 +65,7 @@
 @ui-site-color-5: #EBDD5B;             // yellow
 
 // Sizes
+@font-size:               .9rem;
 @input-font-size:         .9rem;
 @disclosure-arrow-size:   12px;
 


### PR DESCRIPTION
Originally filed an issue with atom-ide-ui https://github.com/facebook-atom/atom-ide-ui/issues/14 but it appears that xatom-ui is missing the @font-size variable. So this just adds that to fix the issue.